### PR TITLE
Feature/#14 Senior List 조회 시 API 호출 로직 문제 해결

### DIFF
--- a/src/pages/senior/hooks/useSeniorList.ts
+++ b/src/pages/senior/hooks/useSeniorList.ts
@@ -6,23 +6,17 @@ import { SeniorAdapter } from "@apis/senior/adapters";
 
 export const useSeniorList = () => {
   const setSeniorList = useSeniorStore((s) => s.setSeniorList);
-
-  return useQuery<SeniorItemType[], Error>({
+  const seniorList = useSeniorStore((s) => s.seniorList);
+  return useQuery<SeniorItemType[], Error, SeniorItemType[], ["seniorList"]>({
     queryKey: ["seniorList"],
     queryFn: async () => {
-      const response = await FetchSeniorAPI();
-      if ("data" in response) {
-        const list = SeniorAdapter.adaptList(response.data);
-        setSeniorList(list);
-        return list;
-      }
-
-      setSeniorList([]);
-      throw new Error(response.message);
+      const data = await FetchSeniorAPI();
+      const list = SeniorAdapter.adaptList(data);
+      setSeniorList(list);
+      return seniorList;
     },
     staleTime: 5 * 60 * 1000,
     refetchOnMount: false,
     retry: 1,
-    placeholderData: [],
   });
 };

--- a/src/pages/senior/index.tsx
+++ b/src/pages/senior/index.tsx
@@ -10,13 +10,10 @@ import {
 import { Topbar } from "@/components/Topbar";
 
 export const Senior = () => {
+  const seniorList = useSeniorStore((state) => state.seniorList);
   const [page, setPage] = useState(1);
   const totalPages = 5;
-
   useSeniorList();
-
-  const seniorList = useSeniorStore((state) => state.seniorList);
-
   return (
     <S.Wrapper>
       <Topbar title="대상자 관리" />


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #14 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요.
- API 호출을 위한 sendRequest 함수의 반환 값을 response.data 전체에서 response.data의 data 필드로 변경함에 따라 기존의 Senior List 조회 코드에서 참조 에러가 발생하였습니다. 
- 이에 따라 Senior List 조회 이후의 데이터 처리 로직을 수정하고 정상 동작하도록 반영했습니다.

## ✅ 체크리스트

- [x] Senior List 조회 로직 정상화

### 스크린샷 (선택)
